### PR TITLE
docs: :pencil: remove release status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # action-update-version
-![ci-badge-checks](https://github.com/outcome-co/action-update-version/workflows/Checks/badge.svg) ![ci-badge-release](https://github.com/outcome-co/action-update-version/workflows/Release/badge.svg)
+![ci-badge-checks](https://github.com/outcome-co/action-update-version/workflows/Checks/badge.svg) 
 
 This Github Action automatically updates the versions of your repositories.
 


### PR DESCRIPTION
The badge will never be updated for master, as the workflow is triggered on tags